### PR TITLE
Bump deps, replace deprecated APIs, and refactoring oh my

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,25 +11,23 @@ plugins {
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
     id("org.jmailen.kotlinter")
-    id("io.sentry.android.gradle") version "4.12.0"
-    id("app.cash.sqldelight") version "2.0.1"
-    id("kotlin-kapt")
+    id("io.sentry.android.gradle") version "4.13.0"
+    id("app.cash.sqldelight") version "2.0.2"
     id("kotlin-parcelize")
     id("com.google.gms.google-services")
 }
 
 val composeBomVersion = "2024.10.01"
-val accompanistVersion = "0.34.0"
-val okhttpVersion = "4.12.0"
-val navVersion = "2.8.3"
+val accompanistVersion = "0.36.0"
+val navVersion = "2.8.4"
 val hiltVersion = "2.52"
 val glideVersion = "4.16.0"
-val ktorVersion = "3.0.0-beta-2"
-val aboutlibrariesVersion = "10.9.1"
+val ktorVersion = "3.0.1"
+val aboutlibrariesVersion = "11.2.3"
 val media3Version = "1.4.1"
 val livekitVersion = "2.2.0"
-val material3Version = "1.4.0-alpha03"
-val androidXTestVersion = "1.6.1"
+val material3Version = "1.4.0-alpha04"
+val androidXTestVersion = "1.6.2"
 
 fun property(fileName: String, propertyName: String, fallbackEnv: String? = null): String? {
     val propsFile = rootProject.file(fileName)
@@ -184,14 +182,14 @@ sentry {
 
 dependencies {
     // Android/Kotlin Core
-    implementation("androidx.core:core-ktx:1.13.1")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:2.0.10")
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:2.0.21")
 
     // Kotlinx - various first-party extensions for Kotlin
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.6.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
-    implementation("androidx.profileinstaller:profileinstaller:1.3.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+    implementation("androidx.profileinstaller:profileinstaller:1.4.1")
 
     // Compose BOM
     val composeBom = platform("androidx.compose:compose-bom:$composeBomVersion")
@@ -204,11 +202,11 @@ dependencies {
     implementation("androidx.compose.ui:ui-util")
     implementation("androidx.compose.material3:material3:$material3Version")
     implementation("androidx.compose.material3:material3-window-size-class:$material3Version")
-    implementation("androidx.compose.material:material-icons-core:1.7.4")
+    implementation("androidx.compose.material:material-icons-core:1.7.5")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.runtime:runtime-livedata")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.activity:activity-compose:1.9.3")
 
     // Accompanist - Jetpack Compose Extensions
@@ -232,7 +230,7 @@ dependencies {
     // Hilt - Dependency Injection
     implementation("com.google.dagger:hilt-android:$hiltVersion")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
-    kapt("com.google.dagger:hilt-compiler:$hiltVersion")
+    ksp("com.google.dagger:hilt-compiler:$hiltVersion")
 
     // Glide - Image Loading
     implementation("com.github.bumptech.glide:glide:$glideVersion")
@@ -243,8 +241,8 @@ dependencies {
     implementation("com.mikepenz:aboutlibraries-compose:$aboutlibrariesVersion")
 
     // Sentry - crash reporting
-    implementation("io.sentry:sentry-android:7.16.0")
-    implementation("io.sentry:sentry-compose-android:7.16.0")
+    implementation("io.sentry:sentry-android:7.18.0")
+    implementation("io.sentry:sentry-compose-android:7.18.0")
 
     // Other AndroidX libraries - used for various things and never seem to have a consistent version
     implementation("androidx.documentfile:documentfile:1.0.1")
@@ -253,7 +251,7 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.2.0-alpha02")
 
     // Libraries used for legacy View-based UI
-    implementation("androidx.constraintlayout:constraintlayout:2.2.0-rc01")
+    implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
 
@@ -261,7 +259,7 @@ dependencies {
     implementation("com.github.hcaptcha:hcaptcha-android-sdk:3.8.1")
 
     // JDK Desugaring - polyfill for new Java APIs
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.2")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
 
     // AndroidX Media3 w/ ExoPlayer
     implementation("androidx.media3:media3-exoplayer:$media3Version")
@@ -274,20 +272,20 @@ dependencies {
     implementation("me.saket.telephoto:zoomable-image-glide:1.0.0-alpha02")
 
     // Persistence
-    implementation("app.cash.sqldelight:android-driver:2.0.1")
+    implementation("app.cash.sqldelight:android-driver:2.0.2")
     implementation("androidx.datastore:datastore:1.1.1")
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     // Markup
     implementation("org.jetbrains:markdown:0.7.3")
-    implementation("dev.snipme:highlights:0.9.1")
+    implementation("dev.snipme:highlights:1.0.0")
 
     // Livekit
     // FIXME temporarily not included, re-add when realtime media is to be implemented
     // implementation "io.livekit:livekit-android:$livekit_version"
 
     // Firebase - Cloud Messaging
-    implementation(platform("com.google.firebase:firebase-bom:33.5.1"))
+    implementation(platform("com.google.firebase:firebase-bom:33.6.0"))
     implementation("com.google.firebase:firebase-messaging")
 
     // Shimmer - loading animations

--- a/app/src/main/java/chat/revolt/activities/InviteActivity.kt
+++ b/app/src/main/java/chat/revolt/activities/InviteActivity.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -71,7 +70,6 @@ class InviteActivity : ComponentActivity() {
         val inviteCode = intent.data?.lastPathSegment
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = Color.Transparent.toArgb()
 
         setContent {
             InviteScreen(

--- a/app/src/main/java/chat/revolt/activities/MainActivity.kt
+++ b/app/src/main/java/chat/revolt/activities/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -266,7 +265,6 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         DynamicColors.applyToActivityIfAvailable(this)
         DynamicColors.applyToActivitiesIfAvailable(RevoltApplication.instance)
-        window.statusBarColor = Color.Transparent.toArgb()
     }
 
     // Same as above for configuration changes (rotation, dark mode, etc.)
@@ -274,7 +272,6 @@ class MainActivity : AppCompatActivity() {
         super.onConfigurationChanged(newConfig)
         DynamicColors.applyToActivityIfAvailable(this)
         DynamicColors.applyToActivitiesIfAvailable(RevoltApplication.instance)
-        window.statusBarColor = Color.Transparent.toArgb()
     }
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -286,7 +283,6 @@ class MainActivity : AppCompatActivity() {
             options.release = BuildConfig.VERSION_NAME
         }
 
-        window.statusBarColor = Color.Transparent.toArgb()
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         installSplashScreen().apply {

--- a/app/src/main/java/chat/revolt/activities/media/ImageViewActivity.kt
+++ b/app/src/main/java/chat/revolt/activities/media/ImageViewActivity.kt
@@ -51,7 +51,7 @@ import chat.revolt.api.settings.SyncedSettings
 import chat.revolt.providers.getAttachmentContentUri
 import chat.revolt.ui.theme.RevoltTheme
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.launch
 import me.saket.telephoto.zoomable.ZoomSpec
 import me.saket.telephoto.zoomable.glide.ZoomableGlideImage
@@ -153,7 +153,7 @@ fun ImageViewScreen(resource: AutumnResource, onClose: () -> Unit = {}) {
                 )
             }?.let { uri ->
                 context.contentResolver.openOutputStream(uri).use { stream ->
-                    val image = RevoltHttp.get(resourceUrl).readBytes()
+                    val image = RevoltHttp.get(resourceUrl).readRawBytes()
                     stream?.write(image)
 
                     context.applicationContext.let {

--- a/app/src/main/java/chat/revolt/activities/media/VideoViewActivity.kt
+++ b/app/src/main/java/chat/revolt/activities/media/VideoViewActivity.kt
@@ -24,7 +24,7 @@ import chat.revolt.providers.getAttachmentContentUri
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.launch
 
 class VideoViewActivity : FragmentActivity() {
@@ -182,7 +182,7 @@ class VideoViewActivity : FragmentActivity() {
                 )
             }?.let { uri ->
                 this@VideoViewActivity.contentResolver.openOutputStream(uri).use { stream ->
-                    val video = RevoltHttp.get(resourceUrl).readBytes()
+                    val video = RevoltHttp.get(resourceUrl).readRawBytes()
                     stream?.write(video)
 
                     this@VideoViewActivity.applicationContext.let {

--- a/app/src/main/java/chat/revolt/api/RevoltAPI.kt
+++ b/app/src/main/java/chat/revolt/api/RevoltAPI.kt
@@ -186,7 +186,7 @@ object RevoltAPI {
         unreads.sync()
     }
 
-    suspend fun connectWS() {
+    fun connectWS() {
         socketCoroutine = CoroutineScope(Dispatchers.IO).launch {
             try {
                 withContext(realtimeContext) {
@@ -223,7 +223,7 @@ object RevoltAPI {
         }
     }
 
-    private suspend fun startSocketOps() {
+    private fun startSocketOps() {
         connectWS()
 
         // Send a ping every roughly 30 seconds else the socket dies

--- a/app/src/main/java/chat/revolt/components/chat/NativeMessageField.kt
+++ b/app/src/main/java/chat/revolt/components/chat/NativeMessageField.kt
@@ -260,8 +260,10 @@ fun NativeMessageField(
                                         size = SuggestionChipDefaults.IconSize,
                                     )
                                 },
-                                modifier = Modifier
-                                    .animateItemPlacement()
+                                modifier = Modifier.animateItem(
+                                    fadeInSpec = null,
+                                    fadeOutSpec = null
+                                )
                             )
                         }
 
@@ -284,8 +286,10 @@ fun NativeMessageField(
                                         )
                                     }
                                 },
-                                modifier = Modifier
-                                    .animateItemPlacement()
+                                modifier = Modifier.animateItem(
+                                    fadeInSpec = null,
+                                    fadeOutSpec = null
+                                )
                             )
                         }
 

--- a/app/src/main/java/chat/revolt/components/markdown/jbm/JBMRenderer.kt
+++ b/app/src/main/java/chat/revolt/components/markdown/jbm/JBMRenderer.kt
@@ -612,7 +612,7 @@ private fun annotateHighlights(
     source: String,
     highlights: List<CodeHighlight>
 ): AnnotatedString {
-    val highlightStyles = highlights.map {
+    val highlightStyles = highlights.mapNotNull {
         when (it) {
             is BoldHighlight -> AnnotatedString.Range(
                 SpanStyle(fontWeight = FontWeight.Bold),
@@ -630,7 +630,7 @@ private fun annotateHighlights(
 
             else -> null
         }
-    }.filterNotNull()
+    }
 
     return AnnotatedString(source, spanStyles = highlightStyles)
 }

--- a/app/src/main/java/chat/revolt/components/media/AudioPlayer.kt
+++ b/app/src/main/java/chat/revolt/components/media/AudioPlayer.kt
@@ -46,7 +46,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import chat.revolt.R
 import chat.revolt.api.RevoltHttp
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -127,7 +127,7 @@ fun AudioPlayer(url: String, filename: String, contentType: String) {
                 )
             }?.let { uri ->
                 context.contentResolver.openOutputStream(uri).use { stream ->
-                    val audio = RevoltHttp.get(url).readBytes()
+                    val audio = RevoltHttp.get(url).readRawBytes()
                     stream?.write(audio)
 
                     context.applicationContext.let {

--- a/app/src/main/java/chat/revolt/components/screens/settings/appearance/CornerRadiusPicker.kt
+++ b/app/src/main/java/chat/revolt/components/screens/settings/appearance/CornerRadiusPicker.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -44,7 +45,7 @@ fun CornerRadiusPicker(percentage: Int, onUpdate: (Int) -> Unit, modifier: Modif
     var showOtherModal by remember { mutableStateOf(false) }
 
     if (showOtherModal) {
-        var sliderPosition by remember { mutableStateOf(percentage.toFloat()) }
+        var sliderPosition by remember { mutableFloatStateOf(percentage.toFloat()) }
         AlertDialog(
             onDismissRequest = { showOtherModal = false },
             title = {

--- a/app/src/main/java/chat/revolt/components/utils/Lifecycle.kt
+++ b/app/src/main/java/chat/revolt/components/utils/Lifecycle.kt
@@ -3,7 +3,7 @@ package chat.revolt.components.utils
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner

--- a/app/src/main/java/chat/revolt/internals/Autocomplete.kt
+++ b/app/src/main/java/chat/revolt/internals/Autocomplete.kt
@@ -21,7 +21,7 @@ object Autocomplete {
         val customResults =
             RevoltAPI.emojiCache.values.filter {
                 it.name?.contains(query, ignoreCase = true) ?: false
-            }.map {
+            }.mapNotNull {
                 if (it.name != null) {
                     AutocompleteSuggestion.Emoji(
                         ":${it.id}:",
@@ -32,7 +32,7 @@ object Autocomplete {
                 } else {
                     null
                 }
-            }.filterNotNull().distinctBy { it.custom?.id }
+            }.distinctBy { it.custom?.id }
 
         return (unicodeResults + customResults)
     }

--- a/app/src/main/java/chat/revolt/providers/AttachmentProvider.kt
+++ b/app/src/main/java/chat/revolt/providers/AttachmentProvider.kt
@@ -7,7 +7,7 @@ import chat.revolt.BuildConfig
 import chat.revolt.R
 import chat.revolt.api.RevoltHttp
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import java.io.File
 
 class AttachmentProvider : FileProvider(R.xml.file_paths)
@@ -25,7 +25,7 @@ suspend fun getAttachmentContentUri(
 
     val response = RevoltHttp.get(resourceUrl)
     val file = File(attachmentsDir, "$id-$filename")
-    file.writeBytes(response.readBytes())
+    file.writeBytes(response.readRawBytes())
 
     return FileProvider.getUriForFile(
         context,

--- a/app/src/main/java/chat/revolt/screens/DefaultDestinationScreen.kt
+++ b/app/src/main/java/chat/revolt/screens/DefaultDestinationScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import chat.revolt.RevoltApplication
@@ -40,7 +38,6 @@ fun DefaultDestinationScreen(
             val activity = context.getComponentActivity() as Activity
             DynamicColors.applyToActivityIfAvailable(activity)
             DynamicColors.applyToActivitiesIfAvailable(RevoltApplication.instance)
-            activity.window.statusBarColor = Color.Transparent.toArgb()
 
             navController.popBackStack(navController.graph.startDestinationRoute!!, true)
             navController.navigate(it)

--- a/app/src/main/java/chat/revolt/screens/chat/dialogs/safety/ReportMessageDialog.kt
+++ b/app/src/main/java/chat/revolt/screens/chat/dialogs/safety/ReportMessageDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
@@ -160,7 +161,7 @@ fun ReportMessageDialog(onDismiss: () -> Unit, messageId: String) {
                                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = reasonDropdownExpanded.value)
                                 },
                                 colors = ExposedDropdownMenuDefaults.textFieldColors(),
-                                modifier = Modifier.menuAnchor()
+                                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable, true)
                             )
 
                             ExposedDropdownMenu(

--- a/app/src/main/java/chat/revolt/screens/chat/dialogs/safety/ReportServerDialog.kt
+++ b/app/src/main/java/chat/revolt/screens/chat/dialogs/safety/ReportServerDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
@@ -126,7 +127,7 @@ fun ReportServerDialog(onDismiss: () -> Unit, serverId: String) {
                                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = reasonDropdownExpanded.value)
                                 },
                                 colors = ExposedDropdownMenuDefaults.textFieldColors(),
-                                modifier = Modifier.menuAnchor()
+                                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable, true)
                             )
 
                             ExposedDropdownMenu(

--- a/app/src/main/java/chat/revolt/screens/chat/dialogs/safety/ReportUserDialog.kt
+++ b/app/src/main/java/chat/revolt/screens/chat/dialogs/safety/ReportUserDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
@@ -122,7 +123,7 @@ fun ReportUserDialog(onDismiss: () -> Unit, userId: String) {
                                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = reasonDropdownExpanded.value)
                                 },
                                 colors = ExposedDropdownMenuDefaults.textFieldColors(),
-                                modifier = Modifier.menuAnchor()
+                                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable, true)
                             )
 
                             ExposedDropdownMenu(

--- a/app/src/main/java/chat/revolt/screens/chat/views/channel/ChannelScreenViewModel.kt
+++ b/app/src/main/java/chat/revolt/screens/chat/views/channel/ChannelScreenViewModel.kt
@@ -2,6 +2,7 @@ package chat.revolt.screens.chat.views.channel
 
 import android.util.Log
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -81,7 +82,7 @@ class ChannelScreenViewModel @Inject constructor(
     var draftContent by mutableStateOf("")
     var draftAttachments = mutableStateListOf<FileArgs>()
     var draftReplyTo = mutableStateListOf<SendMessageReply>()
-    var attachmentUploadProgress by mutableStateOf(0f)
+    var attachmentUploadProgress by mutableFloatStateOf(0f)
 
     var endOfChannel by mutableStateOf(false)
     var didInitialChannelFetch by mutableStateOf(false)
@@ -355,12 +356,18 @@ class ChannelScreenViewModel @Inject constructor(
                 attachments = listOf(),
                 replies = listOf(),
                 tail = items.firstOrNull()?.let {
-                    if (it is ChannelScreenItem.RegularMessage) {
-                        it.message.author == RevoltAPI.selfId
-                    } else if (it is ChannelScreenItem.ProspectiveMessage) {
-                        it.message.author == RevoltAPI.selfId
-                    } else {
-                        false
+                    when (it) {
+                        is ChannelScreenItem.RegularMessage -> {
+                            it.message.author == RevoltAPI.selfId
+                        }
+
+                        is ChannelScreenItem.ProspectiveMessage -> {
+                            it.message.author == RevoltAPI.selfId
+                        }
+
+                        else -> {
+                            false
+                        }
                     }
                 } ?: false
             )
@@ -498,7 +505,7 @@ class ChannelScreenViewModel @Inject constructor(
         ackChannel(channel?.id ?: return, messageId)
     }
 
-    suspend fun startListening(createUiCallbackListener: Boolean = true) {
+    fun startListening(createUiCallbackListener: Boolean = true) {
         viewModelScope.launch {
             withContext(RevoltAPI.realtimeContext) {
                 flow {

--- a/app/src/main/java/chat/revolt/screens/settings/ChangelogsScreen.kt
+++ b/app/src/main/java/chat/revolt/screens/settings/ChangelogsScreen.kt
@@ -60,7 +60,7 @@ class ChangelogsSettingsScreenViewModel @Inject constructor(
     var index by mutableStateOf<ChangelogIndex?>(null)
     var renderedChangelog by mutableStateOf("")
 
-    suspend fun requestChangelog(version: String) {
+    fun requestChangelog(version: String) {
         viewModelScope.launch {
             renderedChangelog = Changelogs(
                 context,
@@ -69,7 +69,7 @@ class ChangelogsSettingsScreenViewModel @Inject constructor(
         }
     }
 
-    suspend fun populate() {
+    fun populate() {
         viewModelScope.launch {
             index = Changelogs(context, kvStorage).fetchChangelogIndex()
         }

--- a/app/src/main/java/chat/revolt/screens/settings/LanguagePickerSettingsScreen.kt
+++ b/app/src/main/java/chat/revolt/screens/settings/LanguagePickerSettingsScreen.kt
@@ -76,15 +76,13 @@ fun LanguagePickerSettingsScreen(
                     )
                 },
                 navigationIcon = {
-                    navController?.let {
-                        IconButton(onClick = {
-                            navController.popBackStack()
-                        }) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                                contentDescription = stringResource(id = R.string.back)
-                            )
-                        }
+                    IconButton(onClick = {
+                        navController.popBackStack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                            contentDescription = stringResource(id = R.string.back)
+                        )
                     }
                 },
             )

--- a/app/src/main/java/chat/revolt/ui/theme/Theme.kt
+++ b/app/src/main/java/chat/revolt/ui/theme/Theme.kt
@@ -1,10 +1,8 @@
 package chat.revolt.ui.theme
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -14,7 +12,6 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
@@ -120,8 +117,6 @@ fun getColorScheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = Color.Transparent.toArgb()
             @Suppress("DEPRECATION")
             ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars =
                 !colorSchemeIsDark

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
-    id("com.android.application") version "8.7.1" apply false
-    id("com.android.library") version "8.7.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.10" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.10" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.10" apply false
-    id("com.google.dagger.hilt.android") version "2.44" apply false
-    id("com.mikepenz.aboutlibraries.plugin") version "10.9.1" apply false
-    id("com.google.devtools.ksp") version "2.0.10-1.0.24" apply false
-    id("org.jmailen.kotlinter") version "4.0.0" apply false
+    id("com.android.application") version "8.7.2" apply false
+    id("com.android.library") version "8.7.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+    id("com.google.dagger.hilt.android") version "2.52" apply false
+    id("com.mikepenz.aboutlibraries.plugin") version "11.2.3" apply false
+    id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
+    id("org.jmailen.kotlinter") version "4.5.0" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }
 


### PR DESCRIPTION
setStatusBarColor is being deprecated and API 35 already sets the color to transparent so just stop setting the color
https://developer.android.com/reference/android/view/Window?hl=en#setStatusBarColor(int)

Use animateItem instead of deprecated animeItemPlacement
https://developer.android.com/jetpack/androidx/releases/compose-animation#1.7.0-alpha06

LocalLifecycleOwner is moved to androidx.lifecycle.compose
https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/package-summary#LocalLifecycleOwner()

Use mutableFloatStateOf rather than mutableStateOf when checking floats

Rewrite if if-else chains into when statements

Remove redundant suspends

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
