### PR TITLE
Make Sentry completely optional

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.mikepenz.aboutlibraries.plugin.StrictMode
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
+import io.sentry.android.gradle.SentryPlugin
+import io.sentry.android.gradle.extensions.SentryPluginExtension
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -11,11 +13,16 @@ plugins {
     alias(libs.plugins.aboutlibraries)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.sentry.android)
+    alias(libs.plugins.sentry.android) apply false
     alias(libs.plugins.sqldelight)
     alias(libs.plugins.google.services)
     id("kotlin-kapt")
     id("kotlin-parcelize")
+}
+
+val sentryEnabled = buildproperty("sentry.dsn", "RVX_SENTRY_DSN") != "";
+if(sentryEnabled) {
+    apply<SentryPlugin>();
 }
 
 fun property(fileName: String, propertyName: String, fallbackEnv: String? = null): String? {
@@ -156,16 +163,18 @@ android {
     }
 }
 
-sentry {
-    autoUploadProguardMapping =
-        buildproperty("sentry.upload_mappings", "RVX_SENTRY_UPLOAD_MAPPINGS") == "true"
+if(sentryEnabled) {
+    configure<SentryPluginExtension> {
+        autoUploadProguardMapping =
+            buildproperty("sentry.upload_mappings", "RVX_SENTRY_UPLOAD_MAPPINGS") == "true"
 
-    tracingInstrumentation {
-        enabled = true
-
-        logcat {
+        tracingInstrumentation {
             enabled = true
-            minLevel = LogcatLevel.WARNING
+
+            logcat {
+                enabled = true
+                minLevel = LogcatLevel.WARNING
+            }
         }
     }
 }

--- a/app/src/main/java/chat/stoat/activities/MainActivity.kt
+++ b/app/src/main/java/chat/stoat/activities/MainActivity.kt
@@ -349,9 +349,11 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        SentryAndroid.init(this) { options ->
-            options.dsn = BuildConfig.SENTRY_DSN
-            options.release = BuildConfig.VERSION_NAME
+        if(BuildConfig.SENTRY_DSN != "") {
+            SentryAndroid.init(this) { options ->
+                options.dsn = BuildConfig.SENTRY_DSN
+                options.release = BuildConfig.VERSION_NAME
+            }
         }
 
         @Suppress("DEPRECATION") // We are fixing a bug in the splash screen


### PR DESCRIPTION
This PR fully disables Sentry if the DSN option is left empty both in stoatbuild.properties and in the RVX_SENTRY_DSN environment variable.

Not only does it prevent Sentry from being Init'd at runtime, but it also disables the Sentry Gradle plugin, since otherwise the plugin throws errors during Gradle syncs.

Sentry is only really necessary if you're shipping an app, not just developing locally. Making Sentry optional should reduce the barrier for entry to new devs.