### PR TITLE
docs: warn about Gradle sync failure on first open before prerequisites are in place

### DIFF
--- a/docs/src/content/docs/contributing/setup.mdx
+++ b/docs/src/content/docs/contributing/setup.mdx
@@ -94,6 +94,12 @@ import { Tabs, TabItem, Steps } from "@astrojs/starlight/components"
 
 5.  Open the project in Android Studio.
 
+    :::caution
+    Android Studio will automatically attempt a Gradle sync when the project is first opened.
+    This sync will fail until steps 8-10 are completed. You can safely dismiss the sync failure and
+    proceed through the remaining steps before syncing manually via
+    **File > Sync Project with Gradle Files**.
+    :::
 6.  Install the required dependencies.
 
     -   Android SDK, latest version


### PR DESCRIPTION
## Why

Android Studio automatically triggers a Gradle sync when a project is first opened. Since `stoatbuild.properties` and other required files from steps 8-10 haven't been copied yet at this point in the guide, the sync fails with a cryptic `NullPointerException`. This can be confusing for new contributors who don't know they can safely dismiss it and continue with the remaining setup steps. 

## Fix 

Added a caution note at step 5 explaing the expected sync failure and instructing the user to dismiss it and complete the remaining prerequisite steps before syncing manually via File > Sync Project with Gradle Files.

## Tested Verified by going through the setup process as a first-time contributor on Windows.