### PR TITLE
fix: correct Chucker no-op artifact name

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,7 +97,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version = "33.15.0
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 shimmer = { module = "com.valentinilk.shimmer:compose-shimmer", version = "1.3.1" }
 chucker = { module = "com.github.chuckerteam.chucker:library", version.ref = "chucker" }
-chucker-noop = { module = "com.github.chuckerteam.chucker:library-noop", version.ref = "chucker" }
+chucker-noop = { module = "com.github.chuckerteam.chucker:library-no-op", version.ref = "chucker" }
 square-logcat = { module = "com.squareup.logcat:logcat", version = "0.1" }
 livekit-android = { module = "io.livekit:livekit-android", version.ref = "livekit" }
 livekit-android-camerax = { module = "io.livekit:android-camerax", version.ref = "livekit" }


### PR DESCRIPTION
The artifact is `library-no-op`, not `library-noop`. Causes release build dependency resolution failure.