### PR TITLE
fix: prevent crash when finalmarkdown native lib is unavailable

### DIFF
--- a/app/src/main/java/chat/stoat/ndk/NativeLibraries.kt
+++ b/app/src/main/java/chat/stoat/ndk/NativeLibraries.kt
@@ -12,8 +12,12 @@ annotation class NativeLibrary(val name: String) {
 object NativeLibraries {
     fun init() {
         System.loadLibrary(NativeLibrary.LIB_NAME_NATIVE_MARKDOWN)
-        System.loadLibrary(NativeLibrary.LIB_NAME_NATIVE_MARKDOWN_V2)
         Stendal.init()
-        FinalMarkdown.init(BuildConfig.DEBUG)
+        try {
+            System.loadLibrary(NativeLibrary.LIB_NAME_NATIVE_MARKDOWN_V2)
+            FinalMarkdown.init(BuildConfig.DEBUG)
+        } catch (_: UnsatisfiedLinkError) {
+            // finalmarkdown native library not available on this architecture
+        }
     }
 }


### PR DESCRIPTION
Wraps finalmarkdown `System.loadLibrary` and `FinalMarkdown.init` in try-catch for `UnsatisfiedLinkError`. The app crashes on startup on architectures where the native library is not bundled.