### PR TITLE
fix: add missing Video field to Embed model

### DIFF
--- a/core/model/src/main/java/chat/stoat/core/model/schemas/Messages.kt
+++ b/core/model/src/main/java/chat/stoat/core/model/schemas/Messages.kt
@@ -70,9 +70,17 @@ data class Embed(
     val siteName: String? = null,
 
     val colour: String? = null,
+    val video: Video? = null,
     val width: Long? = null,
     val height: Long? = null,
     val size: String? = null
+)
+
+@Serializable
+data class Video(
+    val url: String? = null,
+    val width: Long? = null,
+    val height: Long? = null
 )
 
 @Serializable


### PR DESCRIPTION
The server returns a `video` object in embeds (e.g. for GIF providers) but the model lacks the field, causing it to be silently dropped during deserialization.