### PR TITLE
fix: improve emoji picker spacing and emoji sizing

### DIFF
--- a/app/src/main/java/chat/stoat/composables/emoji/EmojiPicker.kt
+++ b/app/src/main/java/chat/stoat/composables/emoji/EmojiPicker.kt
@@ -492,8 +492,8 @@ fun EmojiPicker(
         LazyVerticalGrid(
             state = gridState,
             columns = GridCells.Fixed(spanCount),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
             modifier = Modifier.fillMaxSize()
         ) {
             if (searchResults.isNotEmpty()) {
@@ -589,18 +589,16 @@ fun ColumnScope.PickerItem(
         is EmojiPickerItem.UnicodeEmoji -> {
             Column(
                 modifier = Modifier
-                    .clip(CircleShape)
+                    .aspectRatio(1f)
                     .clickable {
                         onClick(item)
-                    }
-                    .aspectRatio(1f)
-                    .weight(1f),
+                    },
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
                 Text(
                     text = skinToneFactory(item),
-                    style = LocalTextStyle.current.copy(fontSize = 20.sp)
+                    style = LocalTextStyle.current.copy(fontSize = 22.sp)
                 )
             }
         }
@@ -608,13 +606,11 @@ fun ColumnScope.PickerItem(
         is EmojiPickerItem.ServerEmote -> {
             Column(
                 modifier = Modifier
-                    .clip(CircleShape)
+                    .aspectRatio(1f)
                     .combinedClickable(
                         onClick = { onClick(item) },
                         onLongClick = { item.emote.id?.let { onServerEmoteInfo(it) } }
-                    )
-                    .aspectRatio(1f)
-                    .weight(1f),
+                    ),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
@@ -624,7 +620,7 @@ fun ColumnScope.PickerItem(
                     contentScale = ContentScale.Fit,
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(8.dp)
+                        .padding(4.dp)
                 )
             }
         }


### PR DESCRIPTION
closes #116 

Reduced emoji picker grid gaps and increased emoji visual size for better readability. Kept layout compact and improved custom emoji fit so the picker feels denser and clearer.

- Emoji items in the picker currently appear too small and too far apart, which makes them harder to scan and select, especially on smaller screens.
- This update brings spacing and sizing closer to the web experience for better cross-platform consistency.
- The result is a denser, clearer picker that improves quick navigation and emoji selection without changing core behavior.
- Removed `clip(CircleShape)` from emoji picker items to fix edge clipping artifacts and improve rendering consistency. (It was not visible to shape emoji items)

---

<details>
<summary><h3>Video example</h3></summary>

## Currently we have this:

https://github.com/user-attachments/assets/b9b10cf2-206b-4635-ad5b-d6238623f35b


## Whate I made have this:

https://github.com/user-attachments/assets/badf7232-e5ed-4961-a38a-5f7d95ff3d8f

</details>


---
## Screenshots

<img width="848" height="925" alt="Photos_GNkg6C7wQi" src="https://github.com/user-attachments/assets/7c1fe375-8b10-4d9a-93f6-7a67aa9ea445" />
