### PR TITLE
fix: resolve startup loading stall for direct messages

### DIFF
--- a/app/src/main/java/chat/stoat/activities/MainActivity.kt
+++ b/app/src/main/java/chat/stoat/activities/MainActivity.kt
@@ -180,6 +180,11 @@ class MainActivityViewModel @Inject constructor(
         isReady.emit(true)
     }
 
+    private suspend fun showLoginError() {
+        couldNotLogIn.emit(true)
+        startWithoutDestination()
+    }
+
     private fun doPreStartupTasks() {
         Log.d("MainActivity", "Performing pre-startup tasks")
         viewModelScope.launch {
@@ -231,7 +236,7 @@ class MainActivityViewModel @Inject constructor(
 
             if (canReachStoat && !valid) {
                 Log.d("MainActivity", "Session token is invalid, could not log in")
-                couldNotLogIn.emit(true)
+                showLoginError()
             } else {
                 try {
                     Log.d("MainActivity", "Session token is valid, checking onboarding state")
@@ -251,7 +256,7 @@ class MainActivityViewModel @Inject constructor(
                     return@launch startWithoutDestination()
                 } catch (e: Exception) {
                     Log.e("MainActivity", "Failed to check onboarding state, could not log in", e)
-                    couldNotLogIn.emit(true)
+                    showLoginError()
                 }
 
                 try {
@@ -265,7 +270,7 @@ class MainActivityViewModel @Inject constructor(
                     }
                 } catch (e: Exception) {
                     Log.e("MainActivity", "Failed to login, could not log in", e)
-                    couldNotLogIn.emit(true)
+                    showLoginError()
                 }
             }
         }

--- a/app/src/main/java/chat/stoat/screens/chat/views/channel/ChannelScreenViewModel.kt
+++ b/app/src/main/java/chat/stoat/screens/chat/views/channel/ChannelScreenViewModel.kt
@@ -33,6 +33,7 @@ import chat.stoat.api.realtime.frames.receivable.MessageUpdateFrame
 import chat.stoat.api.routes.channel.SendMessageReply
 import chat.stoat.api.routes.channel.ackChannel
 import chat.stoat.api.routes.channel.editMessage
+import chat.stoat.api.routes.channel.fetchSingleChannel
 import chat.stoat.api.routes.channel.fetchMessagesFromChannel
 import chat.stoat.api.routes.channel.sendMessage
 import chat.stoat.api.routes.microservices.autumn.FileArgs
@@ -113,10 +114,25 @@ class ChannelScreenViewModel @Inject constructor(
 
     private var loadMessagesJob: Job? = null
 
+    private suspend fun resolveChannel(channelId: String): Channel? {
+        StoatAPI.channelCache[channelId]?.let { return it }
+
+        return try {
+            fetchSingleChannel(channelId).also { fetched ->
+                if (fetched.id != null) {
+                    StoatAPI.channelCache[fetched.id!!] = fetched
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("ChannelScreenViewModel", "Failed to resolve channel $channelId", e)
+            null
+        }
+    }
+
     fun switchChannel(id: String) {
         // Reset state
         this.loadMessagesJob?.cancel()
-        this.channel = StoatAPI.channelCache[id]
+        this.channel = null
         this.items = mutableStateListOf(ChannelScreenItem.Loading)
         this.activePane = ChannelScreenActivePane.None
         this.typingUsers = mutableStateListOf()
@@ -126,30 +142,45 @@ class ChannelScreenViewModel @Inject constructor(
         this.denyMessageField = false
         this.denyMessageFieldReasonResource = R.string.typing_blank
         this.editingMessage = null
-        this.ageGateUnlocked = channel?.nsfw != true
-        this.showGeoGate = when {
-            channel?.nsfw == true && GeoStateProvider.geoState?.isAgeRestrictedGeo == true -> true
-            else -> false
-        }
-        viewModelScope.launch {
-            if (ageGateUnlocked != true) {
-                ageGateUnlocked = AgeGateUnlockedStorageProvider.getAgeGateUnlocked()
-            }
-        }
+        this.ageGateUnlocked = null
+        this.showGeoGate = false
 
         viewModelScope.launch {
-            putDraftContent(kvStorage.get("draftContent/$id") ?: "", true)
+            val restoredDraft = kvStorage.get("draftContent/$id") ?: ""
+            draftContent = restoredDraft
+            initialTextFieldValue = restoredDraft
+            initialTextFieldValueDirtyMarker = ULID.makeNext()
         }
         this.draftAttachments = mutableStateListOf()
         this.draftReplyTo = mutableStateListOf()
         this.attachmentUploadProgress = 0f
 
         viewModelScope.launch {
+            val resolvedChannel = resolveChannel(id)
+            this@ChannelScreenViewModel.channel = resolvedChannel
+
+            if (resolvedChannel == null) {
+                updateItems(emptyList())
+                ActionChannel.send(
+                    Action.ChatNavigate(
+                        ChatRouterDestination.NoCurrentChannel(null)
+                    )
+                )
+                return@launch
+            }
+
+            this@ChannelScreenViewModel.ageGateUnlocked = resolvedChannel.nsfw != true
+            this@ChannelScreenViewModel.showGeoGate =
+                resolvedChannel.nsfw == true && GeoStateProvider.geoState?.isAgeRestrictedGeo == true
+
+            if (ageGateUnlocked != true) {
+                ageGateUnlocked = AgeGateUnlockedStorageProvider.getAgeGateUnlocked()
+            }
+
             ensureSelfHasMember()
             denyMessageFieldIfNeeded()
+            loadMessages(50, markLastAsRead = true)
         }
-
-        this.loadMessages(50, markLastAsRead = true)
     }
 
     suspend fun unlockAgeGate() {
@@ -260,8 +291,10 @@ class ChannelScreenViewModel @Inject constructor(
      * and, if [setInitial] is true, updates the text field to say the new [content].
      */
     fun putDraftContent(content: String, setInitial: Boolean = false) {
-        viewModelScope.launch {
-            kvStorage.set("draftContent/${channel?.id}", content)
+        channel?.id?.let { channelId ->
+            viewModelScope.launch {
+                kvStorage.set("draftContent/$channelId", content)
+            }
         }
 
         if (editingMessage == null) {


### PR DESCRIPTION
closes #41 

On startup, the app could get stuck in an infinite loading state (most noticeably in direct message routes) until navigating away and back.

- Fixed startup loading stall when opening chat routes from cached destinations
- Added fallback channel resolution from API when channel cache is not ready
- Prevented app startup gate from blocking indefinitely on login error paths
- Avoided writing drafts to an invalid `draftContent/null` key during channel switch

*Kept changes focused to startup navigation and chat draft persistence behavior.*

## Currently we have this:

https://github.com/user-attachments/assets/cf32fbcc-066d-412e-b5bc-5a7ac24ce13b


## What I made have this:

https://github.com/user-attachments/assets/f1c324c7-51e2-47d6-9ec9-007276e591de
