### PR TITLE
fix: prevent duplicate replies and enforce max 5 reply targets

### DIFF
--- a/app/src/main/java/chat/stoat/screens/chat/views/channel/ChannelScreenViewModel.kt
+++ b/app/src/main/java/chat/stoat/screens/chat/views/channel/ChannelScreenViewModel.kt
@@ -72,6 +72,10 @@ import javax.inject.Inject
 class ChannelScreenViewModel @Inject constructor(
     private val kvStorage: KVStorage,
 ) : ViewModel() {
+    private companion object {
+        const val MAX_REPLY_TARGETS = 5
+    }
+
     var items = mutableStateListOf<ChannelScreenItem>()
     var typingUsers = mutableStateListOf<String>()
 
@@ -282,7 +286,7 @@ class ChannelScreenViewModel @Inject constructor(
     }
 
     suspend fun addReplyTo(messageId: String) {
-        if (draftReplyTo.size >= 5) return
+        if (draftReplyTo.size >= MAX_REPLY_TARGETS) return
         if (draftReplyTo.any { it.id == messageId }) return
 
         val shouldMention = kvStorage.getBoolean("mentionOnReply") ?: false
@@ -337,7 +341,7 @@ class ChannelScreenViewModel @Inject constructor(
         // 2. if the user changes the content while the message is being sent we want to persist
         //    the original content
         val content = MessageProcessor.processOutgoing(draftContent, channel?.server)
-        val replyTo = draftReplyTo.toList()
+        val replyTo = draftReplyTo.distinctBy { it.id }.take(MAX_REPLY_TARGETS)
 
         // First we upload (the next 5) attachments...
         viewModelScope.launch {
@@ -717,13 +721,7 @@ class ChannelScreenViewModel @Inject constructor(
                             m is ChannelScreenItem.RegularMessage && m.message.id == it.messageId
                         } as? ChannelScreenItem.RegularMessage ?: return@onEach
 
-                        val shouldMention = kvStorage.getBoolean("mentionOnReply") ?: false
-                        draftReplyTo.add(
-                            SendMessageReply(
-                                message.message.id ?: return@onEach,
-                                shouldMention
-                            )
-                        )
+                        addReplyTo(message.message.id ?: return@onEach)
                     }
 
                     is UiCallback.EditMessage -> {
@@ -742,13 +740,7 @@ class ChannelScreenViewModel @Inject constructor(
                             m is ChannelScreenItem.RegularMessage && m.message.id == it.messageId
                         } as? ChannelScreenItem.RegularMessage ?: return@onEach
 
-                        val shouldMention = kvStorage.getBoolean("mentionOnReply") ?: false
-                        draftReplyTo.add(
-                            SendMessageReply(
-                                message.message.id ?: return@onEach,
-                                shouldMention
-                            )
-                        )
+                        addReplyTo(message.message.id ?: return@onEach)
                         putDraftContent(it.content, true)
                     }
                 }


### PR DESCRIPTION
closes #57 

- fix duplicate reply target addition
- enforce max 5 reply targets consistently across reply entry points
- refactor: use addReplyTo(...) as the single reply entry point to centralize mention + validation logic (deduplicates callback code, no behavior change)

> [!NOTE]
> Previously, reply targets could be added through multiple code paths (e.g. draft and send callbacks), but the max-5 / duplicate validation was not consistently applied in all of them.
> This change routes all reply additions through `addReplyTo(...)`, so duplicate prevention, max-5 enforcement, and mention handling are always applied the same way.


---

## Fixed: Can't reply to the same message multiple times + max 5 reply at once. (See the bug at #57 )

https://github.com/user-attachments/assets/43dae087-93eb-45ad-aa36-3201c04e6eb3

