### PR TITLE
feat: add self-hosted field to login screen

### DIFF
--- a/app/src/main/java/chat/stoat/activities/MainActivity.kt
+++ b/app/src/main/java/chat/stoat/activities/MainActivity.kt
@@ -76,6 +76,9 @@ import chat.stoat.BuildConfig
 import chat.stoat.R
 import chat.stoat.StoatApplication
 import chat.stoat.api.HitRateLimitException
+import chat.stoat.api.STOAT_BASE
+import chat.stoat.api.STOAT_BASE_DEFAULT
+import chat.stoat.api.STOAT_WEB_APP_DEFAULT
 import chat.stoat.api.StoatAPI
 import chat.stoat.api.StoatHttp
 import chat.stoat.api.api
@@ -228,12 +231,28 @@ class MainActivityViewModel @Inject constructor(
                 "We have a session token, checking if it's valid and if we can still reach Stoat"
             )
 
-            val canReachStoat = canReachStoat()
-            val valid = try {
-                StoatAPI.checkSessionToken(token)
-            } catch (e: Throwable) {
-                false
+            var valid = false;
+            var canReachStoat = false;
+            for(attempt in 1..2) {
+                canReachStoat = canReachStoat();
+                if(canReachStoat) {
+                    valid = try {
+                        StoatAPI.checkSessionToken(token)
+                    } catch (e: Throwable) {
+                        false
+                    }
+                } else {
+                    Log.d("MainActivity", "Cannot reach $STOAT_BASE, trying $STOAT_BASE_DEFAULT");
+                    // Fall back to the default instance,
+                    // otherwise the user might get stuck trying to connect to an unreachable instance
+                    updateStoatWebApp(STOAT_WEB_APP_DEFAULT);
+                }
+
+                if(canReachStoat && valid) {
+                    break;
+                }
             }
+
 
             if (canReachStoat && !valid) {
                 Log.d("MainActivity", "Session token is invalid, could not log in")

--- a/app/src/main/java/chat/stoat/activities/MainActivity.kt
+++ b/app/src/main/java/chat/stoat/activities/MainActivity.kt
@@ -86,6 +86,7 @@ import chat.stoat.api.settings.Experiments
 import chat.stoat.api.settings.GeoStateProvider
 import chat.stoat.api.settings.LoadedSettings
 import chat.stoat.api.settings.SyncedSettings
+import chat.stoat.api.updateStoatWebApp
 import chat.stoat.composables.generic.HealthAlert
 import chat.stoat.composables.voice.VoicePermissionSwitch
 import chat.stoat.core.model.schemas.HealthNotice
@@ -206,6 +207,11 @@ class MainActivityViewModel @Inject constructor(
             Log.d("MainActivity", "Checking logged in state")
 
             isConnected.emit(hasInternetConnection())
+
+            val stoatInstanceUrl = kvStorage.get("stoatInstanceUrl");
+            if(!stoatInstanceUrl.isNullOrBlank()) {
+                updateStoatWebApp(stoatInstanceUrl);
+            }
 
             Log.d("MainActivity", "Checking if we can reach Stoat")
 

--- a/app/src/main/java/chat/stoat/api/StoatAPI.kt
+++ b/app/src/main/java/chat/stoat/api/StoatAPI.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.core.net.toUri
 import chat.stoat.BuildConfig
 import chat.stoat.StoatApplication
 import chat.stoat.api.StoatAPI.initialize
@@ -63,8 +64,9 @@ var STOAT_BASE = STOAT_BASE_DEFAULT
 
 const val STOAT_SUPPORT = "https://support.stoat.chat"
 const val STOAT_MARKETING = "https://stoat.chat"
-val STOAT_FILES =
+val STOAT_FILES_DEFAULT =
     if (USE_ALPHA_API) "https://alpha.revolt.chat/autumn" else "https://cdn.stoatusercontent.com"
+var STOAT_FILES = STOAT_FILES_DEFAULT;
 val STOAT_PROXY =
     if (USE_ALPHA_API) "https://alpha.revolt.chat/january" else "https://proxy.stoatusercontent.com"
 const val STOAT_WEB_APP_DEFAULT = "https://stoat.chat"
@@ -79,10 +81,36 @@ var STOAT_WEBSOCKET = STOAT_WEBSOCKET_DEFAULT
 const val STOAT_KJBOOK = "https://stoatchat.github.io/for-android"
 
 fun updateStoatWebApp(webApp: String = STOAT_WEB_APP_DEFAULT) {
-    STOAT_WEB_APP = webApp;
-    STOAT_BASE = "$webApp/api"; // FIXME this wont work with default stoatchat instance
-    var wssRoot = webApp.replace("https:", "wss:").replace("http:", "ws:");
-    STOAT_WEBSOCKET = "$wssRoot/ws"; // FIXME this wont work with default stoatchat instance
+    var sanitisedBaseUrl = webApp.trim();
+
+    if(sanitisedBaseUrl.isBlank()) {
+        sanitisedBaseUrl = STOAT_WEB_APP_DEFAULT;
+    }
+
+    var parsed = sanitisedBaseUrl.toUri();
+
+    val portPart = if (parsed.port == 80 || parsed.port == 443) "" else ":${parsed.port}";
+    val root = "${parsed.scheme}://${parsed.host}${portPart}";
+    val rootWithPort = "${parsed.scheme}://${parsed.host}:${parsed.port}";
+    if(sanitisedBaseUrl.matches(Regex("^$root/+$")) || sanitisedBaseUrl.matches(Regex("^$rootWithPort/+$"))) {
+        // Remove trailing slashes (not sure if it'd actually cause an issue but might as well clean it up)
+        sanitisedBaseUrl = rootWithPort;
+    }
+
+    val isDefaultInstance = sanitisedBaseUrl == STOAT_WEB_APP_DEFAULT;
+
+    if(!isDefaultInstance) {
+        STOAT_WEB_APP = sanitisedBaseUrl;
+        STOAT_BASE = "$sanitisedBaseUrl/api";
+        val wssRoot = sanitisedBaseUrl.replace(Regex("^http(s?):"), "ws$1:");
+        STOAT_WEBSOCKET = "$wssRoot/ws";
+        STOAT_FILES = "$sanitisedBaseUrl/autumn";
+    } else {
+        STOAT_WEB_APP = STOAT_WEB_APP_DEFAULT;
+        STOAT_BASE = STOAT_BASE_DEFAULT;
+        STOAT_WEBSOCKET = STOAT_WEBSOCKET_DEFAULT;
+        STOAT_FILES = STOAT_FILES_DEFAULT;
+    }
 }
 
 fun String.api(): String {

--- a/app/src/main/java/chat/stoat/api/StoatAPI.kt
+++ b/app/src/main/java/chat/stoat/api/StoatAPI.kt
@@ -56,19 +56,34 @@ import chat.stoat.core.model.schemas.Channel as ChannelSchema
 
 private const val USE_ALPHA_API = false
 
-val STOAT_BASE =
+val STOAT_BASE_DEFAULT =
     if (USE_ALPHA_API) "https://alpha.revolt.chat/api" else "https://api.stoat.chat/0.8"
+
+var STOAT_BASE = STOAT_BASE_DEFAULT
+
 const val STOAT_SUPPORT = "https://support.stoat.chat"
 const val STOAT_MARKETING = "https://stoat.chat"
 val STOAT_FILES =
     if (USE_ALPHA_API) "https://alpha.revolt.chat/autumn" else "https://cdn.stoatusercontent.com"
 val STOAT_PROXY =
     if (USE_ALPHA_API) "https://alpha.revolt.chat/january" else "https://proxy.stoatusercontent.com"
-const val STOAT_WEB_APP = "https://stoat.chat"
+const val STOAT_WEB_APP_DEFAULT = "https://stoat.chat"
+var STOAT_WEB_APP = "https://stoat.chat"
+
+
+
 const val STOAT_INVITES = "https://stt.gg"
-val STOAT_WEBSOCKET =
+val STOAT_WEBSOCKET_DEFAULT =
     if (USE_ALPHA_API) "wss://alpha.revolt.chat/ws" else "wss://events.stoat.chat"
+var STOAT_WEBSOCKET = STOAT_WEBSOCKET_DEFAULT
 const val STOAT_KJBOOK = "https://stoatchat.github.io/for-android"
+
+fun updateStoatWebApp(webApp: String = STOAT_WEB_APP_DEFAULT) {
+    STOAT_WEB_APP = webApp;
+    STOAT_BASE = "$webApp/api"; // FIXME this wont work with default stoatchat instance
+    var wssRoot = webApp.replace("https:", "wss:").replace("http:", "ws:");
+    STOAT_WEBSOCKET = "$wssRoot/ws"; // FIXME this wont work with default stoatchat instance
+}
 
 fun String.api(): String {
     return "$STOAT_BASE$this"

--- a/app/src/main/java/chat/stoat/api/StoatAPI.kt
+++ b/app/src/main/java/chat/stoat/api/StoatAPI.kt
@@ -87,13 +87,19 @@ fun updateStoatWebApp(webApp: String = STOAT_WEB_APP_DEFAULT) {
         sanitisedBaseUrl = STOAT_WEB_APP_DEFAULT;
     }
 
+    if(!sanitisedBaseUrl.matches(Regex("^https?://.+"))) {
+        // Default to https if no scheme provided
+        sanitisedBaseUrl = "https://${sanitisedBaseUrl}";
+    }
+
     var parsed = sanitisedBaseUrl.toUri();
 
     val portPart = if (parsed.port == 80 || parsed.port == 443) "" else ":${parsed.port}";
     val root = "${parsed.scheme}://${parsed.host}${portPart}";
     val rootWithPort = "${parsed.scheme}://${parsed.host}:${parsed.port}";
     if(sanitisedBaseUrl.matches(Regex("^$root/+$")) || sanitisedBaseUrl.matches(Regex("^$rootWithPort/+$"))) {
-        // Remove trailing slashes (not sure if it'd actually cause an issue but might as well clean it up)
+        // Remove trailing slashes
+        // (not sure if it'd actually cause an issue but might as well clean it up)
         sanitisedBaseUrl = rootWithPort;
     }
 

--- a/app/src/main/java/chat/stoat/composables/generic/FormTextField.kt
+++ b/app/src/main/java/chat/stoat/composables/generic/FormTextField.kt
@@ -23,7 +23,8 @@ fun FormTextField(
     action: ImeAction = ImeAction.Done,
     supportingText: @Composable (() -> Unit)? = null,
     singleLine: Boolean = true,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    placeholder: @Composable (() -> Unit)? = null,
 ) {
     TextField(
         value = value,
@@ -34,6 +35,7 @@ fun FormTextField(
         label = { Text(label) },
         supportingText = supportingText,
         enabled = enabled,
-        modifier = modifier
+        modifier = modifier,
+        placeholder = placeholder
     )
 }

--- a/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
+++ b/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
@@ -133,6 +133,8 @@ class LoginViewModel @Inject constructor(
                         StoatAPI.loginAs(token)
                         StoatAPI.setSessionId(response.firstUserHints.token)
 
+                        kvStorage.set("stoatInstanceUrl", _stoatInstanceUrl);
+
                         _navigateTo = "home"
                     } catch (e: Error) {
                         _error = e.message ?: "Unknown error"

--- a/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
+++ b/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
@@ -12,8 +12,12 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.overscroll
+import androidx.compose.foundation.rememberOverscrollEffect
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextObfuscationMode
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -206,7 +210,9 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
             .fillMaxSize()
             .padding(20.dp)
             .imePadding()
-            .safeDrawingPadding(),
+            .safeDrawingPadding()
+            .verticalScroll(rememberScrollState())
+            .overscroll(rememberOverscrollEffect()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -230,18 +236,22 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
 
             Column(
                 modifier = Modifier
-                    .width(270.dp),
+                    .width(270.dp)
+                    .overscroll(rememberOverscrollEffect())
+                    .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 FormTextField(
                     value = viewModel.stoatInstanceUrl,
-                    label = "Stoat instance", // FIXME hardcoded string
+                    label = stringResource(R.string.stoat_instance), // TODO: needs translations
                     type = KeyboardType.Uri,
                     action = ImeAction.Next,
                     onChange = viewModel::setStoatInstanceUrl,
                     modifier = Modifier
-                        .padding(vertical = 25.dp)
+                        .padding(vertical = 25.dp),
+                    placeholder = {Text(text = STOAT_WEB_APP_DEFAULT)},
+                    supportingText = {Text(text = stringResource(R.string.stoat_instance_hint))}
                 )
                 FormTextField(
                     value = viewModel.email,

--- a/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
+++ b/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
@@ -50,10 +50,12 @@ import androidx.navigation.NavController
 import chat.stoat.R
 import chat.stoat.StoatApplication
 import chat.stoat.api.STOAT_WEB_APP
+import chat.stoat.api.STOAT_WEB_APP_DEFAULT
 import chat.stoat.api.StoatAPI
 import chat.stoat.api.routes.account.EmailPasswordAssessment
 import chat.stoat.api.routes.account.negotiateAuthentication
 import chat.stoat.api.routes.onboard.needsOnboarding
+import chat.stoat.api.updateStoatWebApp
 import chat.stoat.composables.generic.FormTextField
 import chat.stoat.composables.generic.Weblink
 import chat.stoat.persistence.KVStorage
@@ -73,6 +75,10 @@ class LoginViewModel @Inject constructor(
     private var _password by mutableStateOf("")
     val password: String
         get() = _password
+
+    private var _stoatInstanceUrl by mutableStateOf(STOAT_WEB_APP)
+    val stoatInstanceUrl: String
+        get() = _stoatInstanceUrl
 
     private var _error by mutableStateOf<String?>(null)
     val error: String?
@@ -120,8 +126,7 @@ class LoginViewModel @Inject constructor(
                         kvStorage.set("sessionId", id)
 
                         val onboard = needsOnboarding(token)
-                        if (onboard) {
-                            _navigateTo = "onboarding"
+                        if (onboard) { _navigateTo = "onboarding"
                             return@launch
                         }
 
@@ -147,6 +152,11 @@ class LoginViewModel @Inject constructor(
 
     fun setPassword(password: String) {
         _password = password
+    }
+
+    fun setStoatInstanceUrl(url: String = STOAT_WEB_APP) {
+        _stoatInstanceUrl = url;
+        updateStoatWebApp(url);
     }
 }
 
@@ -222,6 +232,15 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                FormTextField(
+                    value = viewModel.stoatInstanceUrl,
+                    label = "Stoat instance", // FIXME hardcoded string
+                    type = KeyboardType.Uri,
+                    action = ImeAction.Next,
+                    onChange = viewModel::setStoatInstanceUrl,
+                    modifier = Modifier
+                        .padding(vertical = 25.dp)
+                )
                 FormTextField(
                     value = viewModel.email,
                     label = stringResource(R.string.email),

--- a/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
+++ b/app/src/main/java/chat/stoat/screens/login/LoginScreen.kt
@@ -1,5 +1,6 @@
 package chat.stoat.screens.login
 
+import android.content.res.Configuration
 import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -35,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -60,6 +62,7 @@ import chat.stoat.api.routes.account.EmailPasswordAssessment
 import chat.stoat.api.routes.account.negotiateAuthentication
 import chat.stoat.api.routes.onboard.needsOnboarding
 import chat.stoat.api.updateStoatWebApp
+import chat.stoat.composables.generic.CollapsibleCard
 import chat.stoat.composables.generic.FormTextField
 import chat.stoat.composables.generic.Weblink
 import chat.stoat.persistence.KVStorage
@@ -205,10 +208,12 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
         }
     }
 
+    val configuration = LocalConfiguration.current;
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(20.dp)
+            .padding(10.dp)
             .imePadding()
             .safeDrawingPadding()
             .verticalScroll(rememberScrollState())
@@ -235,24 +240,16 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
             )
 
             Column(
-                modifier = Modifier
-                    .width(270.dp)
+                modifier = (when(configuration.orientation) {
+                        Configuration.ORIENTATION_LANDSCAPE -> Modifier.fillMaxWidth()
+                        else -> Modifier.width(270.dp)
+                    })
                     .overscroll(rememberOverscrollEffect())
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                FormTextField(
-                    value = viewModel.stoatInstanceUrl,
-                    label = stringResource(R.string.stoat_instance), // TODO: needs translations
-                    type = KeyboardType.Uri,
-                    action = ImeAction.Next,
-                    onChange = viewModel::setStoatInstanceUrl,
-                    modifier = Modifier
-                        .padding(vertical = 25.dp),
-                    placeholder = {Text(text = STOAT_WEB_APP_DEFAULT)},
-                    supportingText = {Text(text = stringResource(R.string.stoat_instance_hint))}
-                )
+
                 FormTextField(
                     value = viewModel.email,
                     label = stringResource(R.string.email),
@@ -307,6 +304,23 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
                     url = "$STOAT_WEB_APP/login/reset",
                     modifier = Modifier.padding(vertical = 7.dp)
                 )
+
+                CollapsibleCard(
+                    header = {Text(text = stringResource(R.string.login_advanced_options))},
+                    modifier = Modifier.width(300.dp)
+                ) {
+                    FormTextField(
+                        value = viewModel.stoatInstanceUrl,
+                        label = stringResource(R.string.stoat_instance), // TODO: needs translations
+                        type = KeyboardType.Uri,
+                        action = ImeAction.Next,
+                        onChange = viewModel::setStoatInstanceUrl,
+                        modifier = Modifier
+                            .padding(vertical = 5.dp),
+                        placeholder = {Text(text = STOAT_WEB_APP_DEFAULT)},
+                        supportingText = {Text(text = stringResource(R.string.stoat_instance_hint))}
+                    )
+                }
 
                 if (viewModel.error != null) {
                     Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,8 @@
     <string name="login_onboarding_body">Stoat is one of the best ways to stay connected with your friends and community, anywhere, anytime.</string>
 
     <string name="stoat_instance">Stoat host</string>
-    <string name="stoat_instance_hint">This is the base URL of the Stoat instance you\'re logging in to, if you want to connect to self-hosted instances. You can leave this blank to use the official Stoat instance.</string>
+    <string name="stoat_instance_hint">This is the base URL of the Stoat instance you\'re logging in to. If you\'re unsure, leave this field blank to use the official Stoat instance.</string>
+    <string name="login_advanced_options">Advanced options</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="login_onboarding_heading">Find your community, connect with the world.</string>
     <string name="login_onboarding_body">Stoat is one of the best ways to stay connected with your friends and community, anywhere, anytime.</string>
 
+    <string name="stoat_instance">Stoat host</string>
+    <string name="stoat_instance_hint">This is the base URL of the Stoat instance you\'re logging in to, if you want to connect to self-hosted instances. You can leave this blank to use the official Stoat instance.</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
 


### PR DESCRIPTION
This PR adds an "advanced options" card to the login screen. It currently only contains a Stoat host URL field, which allows the user to specify a custom Stoat instance. This modifies the `STOAT_BASE`, `STOAT_WEB_APP` and related globals. The setting defaults to the official Stoat.chat instance (this is also the case if the field is blank). 

If the app is unable to reach the Stoat instance at startup it will fall back to the official Stoat instance so as to avoid locking the user out.

<details>
<summary>Screenshots</summary>

<img width="360" height="803" alt="image" src="https://github.com/user-attachments/assets/d5cf2594-5b50-445d-b425-bd8bad2adb89" />

<img width="360" height="803" alt="image" src="https://github.com/user-attachments/assets/049ed315-7b3f-4145-ade2-d02e69cb4bc2" />

<img width="360" height="803" alt="image" src="https://github.com/user-attachments/assets/fa5ec1f1-76a9-4f2e-8da2-c059c9369cf3" />

</details>

Closes #12 