### PR TITLE
fix: refresh friend request state immediately after add

### DIFF
--- a/app/src/main/java/chat/stoat/api/routes/user/Relationships.kt
+++ b/app/src/main/java/chat/stoat/api/routes/user/Relationships.kt
@@ -1,5 +1,6 @@
 package chat.stoat.api.routes.user
 
+import chat.stoat.api.StoatAPI
 import chat.stoat.api.StoatAPIError
 import chat.stoat.api.StoatHttp
 import chat.stoat.api.StoatJson
@@ -12,6 +13,27 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.serialization.SerializationException
+
+private fun updateOutgoingRelationshipInCache(friendTag: String, userIdHint: String?) {
+    if (userIdHint != null) {
+        val byId = StoatAPI.userCache[userIdHint]
+        if (byId != null) {
+            StoatAPI.userCache[userIdHint] = byId.copy(relationship = "Outgoing")
+            return
+        }
+    }
+
+    val username = friendTag.substringBeforeLast("#", "")
+    val discriminator = friendTag.substringAfterLast("#", "")
+    if (username.isBlank() || discriminator.isBlank()) return
+
+    val user = StoatAPI.userCache.values.firstOrNull {
+        it.username == username && it.discriminator == discriminator
+    } ?: return
+
+    val userId = user.id ?: return
+    StoatAPI.userCache[userId] = user.copy(relationship = "Outgoing")
+}
 
 suspend fun blockUser(userId: String) {
     val response = StoatHttp.put("/users/$userId/block".api())
@@ -37,7 +59,7 @@ suspend fun unblockUser(userId: String) {
     }
 }
 
-suspend fun friendUser(username: String) {
+suspend fun friendUser(username: String, userIdHint: String? = null) {
     val response = StoatHttp.post("/users/friend".api()) {
         contentType(ContentType.Application.Json)
         setBody(mapOf("username" to username))
@@ -48,7 +70,8 @@ suspend fun friendUser(username: String) {
         val error = StoatJson.decodeFromString(StoatAPIError.serializer(), body)
         throw Exception(error.type)
     } catch (e: SerializationException) {
-        // Not an error
+        // Not an error. Apply a local cache fallback so UI updates immediately.
+        updateOutgoingRelationshipInCache(username, userIdHint)
     }
 }
 

--- a/app/src/main/java/chat/stoat/composables/screens/settings/UserButtons.kt
+++ b/app/src/main/java/chat/stoat/composables/screens/settings/UserButtons.kt
@@ -65,7 +65,7 @@ fun UserButtons(
             onClick = {
                 scope.launch {
                     try {
-                        friendUser("${user.username}#${user.discriminator}")
+                        friendUser("${user.username}#${user.discriminator}", user.id)
                     } catch (e: Exception) {
                         // Button did nothing, but not an error
                         if (e.message == "NoEffect") return@launch
@@ -92,7 +92,7 @@ fun UserButtons(
                         onClick = {
                             scope.launch {
                                 try {
-                                    friendUser("${user.username}#${user.discriminator}")
+                                    friendUser("${user.username}#${user.discriminator}", user.id)
                                 } catch (e: Exception) {
                                     if (e.message == "NoEffect") return@launch
                                     logcat(LogPriority.ERROR) { e.asLog() }


### PR DESCRIPTION
closes #39 

## What changed
- Moved the immediate relationship cache update to a single place in the API relationship flow.
- Removed duplicated profile UI-side cache mutation.
- Added a `userId` hint path for deterministic outgoing-state updates after a successful Add Friend call.

## Currently we have this
After tapping Add Friend on a user profile, the button state did not update immediately, and the new request did not appear in the Outgoing list until the app was restarted.


https://github.com/user-attachments/assets/68fa94e5-4abb-4bfd-90e9-5d7ef4ea9fef


## What I made have this
After a successful Add Friend action, relationship state now updates to Outgoing immediately, so both the profile button and the Outgoing requests list refresh right away without restarting the app.


https://github.com/user-attachments/assets/2cb4fb33-f258-474e-a084-15efb2bff716

