### PR TITLE
feat: add Edit Channel button to channel context sheet

### DIFF
--- a/app/src/main/java/chat/stoat/sheets/ChannelContextSheet.kt
+++ b/app/src/main/java/chat/stoat/sheets/ChannelContextSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,9 +20,15 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import chat.stoat.R
 import chat.stoat.api.StoatAPI
+import chat.stoat.api.internals.PermissionBit
+import chat.stoat.api.internals.has
+import chat.stoat.callbacks.Action
+import chat.stoat.callbacks.ActionChannel
 import chat.stoat.composables.generic.SheetButton
-
+import chat.stoat.core.model.schemas.ChannelType
 import chat.stoat.internals.Platform
+import chat.stoat.internals.extensions.rememberChannelPermissions
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -40,6 +47,7 @@ fun ChannelContextSheet(channelId: String, onHideSheet: suspend () -> Unit) {
 
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
+    val permissions by rememberChannelPermissions(channelId)
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -95,6 +103,34 @@ fun ChannelContextSheet(channelId: String, onHideSheet: suspend () -> Unit) {
             }
         }
     )
+
+    if (
+        (permissions has PermissionBit.ManageChannel)
+        && (channel.channelType != ChannelType.SavedMessages && channel.channelType != ChannelType.DirectMessage)
+    ) {
+        SheetButton(
+            headlineContent = {
+                Text(
+                    text = stringResource(id = R.string.channel_context_sheet_actions_edit_channel),
+                )
+            },
+            leadingContent = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_edit_24dp),
+                    contentDescription = null
+                )
+            },
+            onClick = {
+                coroutineScope.launch {
+                    onHideSheet()
+                }
+                coroutineScope.launch {
+                    delay(100) // wait for the sheet to close or at least start closing
+                    ActionChannel.send(Action.TopNavigate("settings/channel/$channelId"))
+                }
+            }
+        )
+    }
 
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,6 +410,7 @@
     <string name="channel_context_sheet_actions_copy_id">Copy ID</string>
     <string name="channel_context_sheet_actions_copy_id_copied">Copied channel ID to clipboard</string>
     <string name="channel_context_sheet_actions_mark_read">Mark as read</string>
+    <string name="channel_context_sheet_actions_edit_channel">Edit Channel</string>
 
     <string name="server_context_sheet_description_empty">There hasn\'t been a description set for this server yet.</string>
 


### PR DESCRIPTION
closes #114 

## What changed

- Added an "Edit Channel" button to the channel long-press context sheet (ChannelContextSheet)
- The button is gated behind the ManageChannel permission and excluded for SavedMessages and DirectMessage channel types
- Navigation uses the existing ActionChannel/TopNavigate pattern consistent with ChannelInfoSheet
- Added the `channel_context_sheet_actions_edit_channel` string resource

## Currently we have this

The channel context sheet (long-press on a channel in the sidebar) only offers "Copy ID" and "Mark as read" actions, with no way to navigate to channel settings from there.

https://github.com/user-attachments/assets/089935a1-9717-46d5-af34-8fdad60909d6


## What I made have this

Users with ManageChannel permission can now tap "Edit Channel" in the channel context sheet to navigate directly to the channel settings screen.

https://github.com/user-attachments/assets/a4b331e8-75e2-48b7-ba1c-ff6eb5279a77

