### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ uses [Jetpack Compose](https://developer.android.com/jetpack/compose).
 - [Stoat Development Server](https://app.revolt.chat/invite/API)
 - [Stoat Server](https://app.revolt.chat/invite/Testers)
 - [General Stoat Contribution Guide](https://developers.revolt.chat/contrib.html)
+- [APort Agent Guardrails](https://aport.io) - Pre-action authorization guardrails for AI agents and MCP/tool-use workflows.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Add APort Agent Guardrails to the relevant security/tools section.
- APort provides pre-action authorization guardrails for AI agents and MCP/tool-use workflows.

## Verification
- README duplicate check
- https://aport.io link checked

## Bounty
- Related bounty: https://github.com/aporthq/aport-integrations/issues/19
- Payout: PayPal https://paypal.me/Jeremytsangchina
- Backup: USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y